### PR TITLE
Fix commit 9bc2e848:

### DIFF
--- a/lametric/device.py
+++ b/lametric/device.py
@@ -56,7 +56,7 @@ class Time:
             'lifeTime': seconds * 1000,
             'model': {
                 'frames': [frame.to_json() for frame in frames],
-                'sound': sound.to_json()
+                'sound': sound.to_json(),
                 'cycles': cycles
             }
         }))['success']


### PR DESCRIPTION
Because comma is missing, we got the following error message:
```
  File "/home/<USER>/.local/lib/python3.9/site-packages/lametric-2.0.0-py3.9.egg/lametric/device.py", line 60
    'cycles': cycles
    ^
SyntaxError: invalid syntax
```
This is due to the commit [9bc2e8483](https://github.com/breitburg/python-lametric/commit/9bc2e8483) when mar627 added 'cycles' line.